### PR TITLE
Improve OpenAPI docs

### DIFF
--- a/CSharpFunctionalExtensions.HttpResults.Generators/Builders/ResultExtensionsClassBuilder.cs
+++ b/CSharpFunctionalExtensions.HttpResults.Generators/Builders/ResultExtensionsClassBuilder.cs
@@ -23,6 +23,7 @@ public class ResultExtensionsClassBuilder(List<string> requiredNamespaces, List<
         new ToFileStreamHttpResultStreamE(),
         new ToJsonHttpResultTE(),
         new ToNoContentHttpResultTE(),
-        new ToStatusCodeHttpResultTE()
+        new ToStatusCodeHttpResultTE(),
+        new ToOkHttpResultTE()
     ];
 }

--- a/CSharpFunctionalExtensions.HttpResults.Generators/Builders/ResultExtensionsClassBuilder.cs
+++ b/CSharpFunctionalExtensions.HttpResults.Generators/Builders/ResultExtensionsClassBuilder.cs
@@ -21,7 +21,7 @@ public class ResultExtensionsClassBuilder(List<string> requiredNamespaces, List<
         new ToCreatedHttpResultTE(),
         new ToFileHttpResultByteArrayE(),
         new ToFileStreamHttpResultStreamE(),
-        new ToHttpResultTE(),
+        new ToJsonHttpResultTE(),
         new ToNoContentHttpResultTE(),
         new ToStatusCodeHttpResultTE()
     ];

--- a/CSharpFunctionalExtensions.HttpResults.Generators/Builders/ResultExtensionsClassBuilder.cs
+++ b/CSharpFunctionalExtensions.HttpResults.Generators/Builders/ResultExtensionsClassBuilder.cs
@@ -22,6 +22,7 @@ public class ResultExtensionsClassBuilder(List<string> requiredNamespaces, List<
         new ToFileHttpResultByteArrayE(),
         new ToFileStreamHttpResultStreamE(),
         new ToHttpResultTE(),
-        new ToNoContentHttpResultTE()
+        new ToNoContentHttpResultTE(),
+        new ToStatusCodeHttpResultTE()
     ];
 }

--- a/CSharpFunctionalExtensions.HttpResults.Generators/ResultExtensions/ToJsonHttpResultTE.cs
+++ b/CSharpFunctionalExtensions.HttpResults.Generators/ResultExtensions/ToJsonHttpResultTE.cs
@@ -1,6 +1,6 @@
 ﻿namespace CSharpFunctionalExtensions.HttpResults.Generators.ResultExtensions;
 
-internal class ToHttpResultTE: IGenerateMethods
+internal class ToJsonHttpResultTE: IGenerateMethods
 {
     public string Generate(string mapperClassName, string resultErrorType, string httpResultType)
     {
@@ -8,7 +8,7 @@ internal class ToHttpResultTE: IGenerateMethods
                  /// <summary>
                  /// Returns a <see cref="JsonHttpResult{TValue}"/> in case of success result. Returns custom mapping in case of failure. You can override the success status code.
                  /// </summary>
-                 public static Results<JsonHttpResult<T>, {{httpResultType}}> ToHttpResult<T>(this Result<T,{{resultErrorType}}> result, int successStatusCode = 200)
+                 public static Results<JsonHttpResult<T>, {{httpResultType}}> ToJsonHttpResult<T>(this Result<T,{{resultErrorType}}> result, int successStatusCode = 200)
                  {
                      if (result.IsSuccess) return TypedResults.Json(result.Value, statusCode: successStatusCode);
                      
@@ -18,9 +18,9 @@ internal class ToHttpResultTE: IGenerateMethods
                  /// <summary>
                  /// Returns a <see cref="JsonHttpResult{TValue}"/> in case of success result. Returns custom mapping in case of failure. You can override the success status code.
                  /// </summary>
-                 public static async Task<Results<JsonHttpResult<T>, {{httpResultType}}>> ToHttpResult<T>(this Task<Result<T,{{resultErrorType}}>> result, int successStatusCode = 200)
+                 public static async Task<Results<JsonHttpResult<T>, {{httpResultType}}>> ToJsonHttpResult<T>(this Task<Result<T,{{resultErrorType}}>> result, int successStatusCode = 200)
                  {
-                     return (await result).ToHttpResult(successStatusCode);
+                     return (await result).ToJsonHttpResult(successStatusCode);
                  }
                  """;
     }

--- a/CSharpFunctionalExtensions.HttpResults.Generators/ResultExtensions/ToNoContentHttpResultTE.cs
+++ b/CSharpFunctionalExtensions.HttpResults.Generators/ResultExtensions/ToNoContentHttpResultTE.cs
@@ -6,21 +6,21 @@ internal class ToNoContentHttpResultTE: IGenerateMethods
     {
         return $$"""
                  /// <summary>
-                 /// Discards the value of <see cref="Result{T,E}"/> and Returns a <see cref="StatusCodeHttpResult"/> in case of success result. Returns custom mapping in case of failure. You can override the success status code.
+                 /// Discards the value of <see cref="Result{T,E}"/> and Returns a <see cref="NoContent"/> in case of success result. Returns custom mapping in case of failure.
                  /// </summary>
-                 public static Results<StatusCodeHttpResult, {{httpResultType}}> ToNoContentHttpResult<T>(this Result<T,{{resultErrorType}}> result, int successStatusCode = 204)
+                 public static Results<NoContent, {{httpResultType}}> ToNoContentHttpResult<T>(this Result<T,{{resultErrorType}}> result)
                  {
-                     if (result.IsSuccess) return TypedResults.StatusCode(successStatusCode);
+                     if (result.IsSuccess) return TypedResults.NoContent();
                      
                      return new {{mapperClassName}}().Map(result.Error);
                  }
                  
                  /// <summary>
-                 /// Discards the value of <see cref="Result{T,E}"/> and Returns a <see cref="StatusCodeHttpResult"/> in case of success result. Returns custom mapping in case of failure. You can override the success status code.
+                 /// Discards the value of <see cref="Result{T,E}"/> and Returns a <see cref="NoContent"/> in case of success result. Returns custom mapping in case of failure.
                  /// </summary>
-                 public static async Task<Results<StatusCodeHttpResult, {{httpResultType}}>> ToNoContentHttpResult<T>(this Task<Result<T,{{resultErrorType}}>> result, int successStatusCode = 204)
+                 public static async Task<Results<NoContent, {{httpResultType}}>> ToNoContentHttpResult<T>(this Task<Result<T,{{resultErrorType}}>> result)
                  {
-                     return (await result).ToNoContentHttpResult(successStatusCode);
+                     return (await result).ToNoContentHttpResult();
                  }
                  """;
     }

--- a/CSharpFunctionalExtensions.HttpResults.Generators/ResultExtensions/ToOkHttpResultTE.cs
+++ b/CSharpFunctionalExtensions.HttpResults.Generators/ResultExtensions/ToOkHttpResultTE.cs
@@ -1,0 +1,27 @@
+﻿namespace CSharpFunctionalExtensions.HttpResults.Generators.ResultExtensions;
+
+internal class ToOkHttpResultTE: IGenerateMethods
+{
+    public string Generate(string mapperClassName, string resultErrorType, string httpResultType)
+    {
+        return $$"""
+                 /// <summary>
+                 /// Returns a <see cref="Ok{TValue}"/> in case of success result. Returns custom mapping in case of failure.
+                 /// </summary>
+                 public static Results<Ok<T>, {{httpResultType}}> ToOkHttpResult<T>(this Result<T,{{resultErrorType}}> result)
+                 {
+                     if (result.IsSuccess) return TypedResults.Ok(result.Value);
+                     
+                     return new {{mapperClassName}}().Map(result.Error);
+                 }
+                 
+                 /// <summary>
+                 /// Returns a <see cref="Ok{TValue}"/> in case of success result. Returns custom mapping in case of failure.
+                 /// </summary>
+                 public static async Task<Results<Ok<T>, {{httpResultType}}>> ToOkHttpResult<T>(this Task<Result<T,{{resultErrorType}}>> result)
+                 {
+                     return (await result).ToOkHttpResult();
+                 }
+                 """;
+    }
+}

--- a/CSharpFunctionalExtensions.HttpResults.Generators/ResultExtensions/ToStatusCodeHttpResultTE.cs
+++ b/CSharpFunctionalExtensions.HttpResults.Generators/ResultExtensions/ToStatusCodeHttpResultTE.cs
@@ -1,0 +1,27 @@
+﻿namespace CSharpFunctionalExtensions.HttpResults.Generators.ResultExtensions;
+
+internal class ToStatusCodeHttpResultTE: IGenerateMethods
+{
+    public string Generate(string mapperClassName, string resultErrorType, string httpResultType)
+    {
+        return $$"""
+                 /// <summary>
+                 /// Discards the value of <see cref="Result{T,E}"/> and Returns a <see cref="StatusCodeHttpResult"/> in case of success result. Returns custom mapping in case of failure. You can override the success status code.
+                 /// </summary>
+                 public static Results<StatusCodeHttpResult, {{httpResultType}}> ToStatusCodeHttpResult<T>(this Result<T,{{resultErrorType}}> result, int successStatusCode = 204)
+                 {
+                     if (result.IsSuccess) return TypedResults.StatusCode(successStatusCode);
+                     
+                     return new {{mapperClassName}}().Map(result.Error);
+                 }
+                 
+                 /// <summary>
+                 /// Discards the value of <see cref="Result{T,E}"/> and Returns a <see cref="StatusCodeHttpResult"/> in case of success result. Returns custom mapping in case of failure. You can override the success status code.
+                 /// </summary>
+                 public static async Task<Results<StatusCodeHttpResult, {{httpResultType}}>> ToStatusCodeHttpResult<T>(this Task<Result<T,{{resultErrorType}}>> result, int successStatusCode = 204)
+                 {
+                     return (await result).ToStatusCodeHttpResult(successStatusCode);
+                 }
+                 """;
+    }
+}

--- a/CSharpFunctionalExtensions.HttpResults.Tests/ResultExtensions/ToJsonHttpResultT.cs
+++ b/CSharpFunctionalExtensions.HttpResults.Tests/ResultExtensions/ToJsonHttpResultT.cs
@@ -4,27 +4,27 @@ using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace CSharpFunctionalExtensions.HttpResults.Tests.ResultExtensions;
 
-public class ToHttpResultT
+public class ToJsonHttpResultT
 {
     [Fact]
-    public void ResultT_Success_can_be_mapped_to_HttpResult()
+    public void ResultT_Success_can_be_mapped_to_JsonHttpResult()
     {
         var value = "foo";
         
         var result = Result.Success(value)
-            .ToHttpResult().Result as JsonHttpResult<string>;
+            .ToJsonHttpResult().Result as JsonHttpResult<string>;
         
         result!.StatusCode.Should().Be(200);
         result!.Value.Should().Be(value);
     }
     
     [Fact]
-    public async Task ResultT_Success_can_be_mapped_to_HttpResult_Async()
+    public async Task ResultT_Success_can_be_mapped_to_JsonHttpResult_Async()
     {
         var value = "foo";
         
         var result = (await Task.FromResult(Result.Success(value))
-            .ToHttpResult()).Result as JsonHttpResult<string>;
+            .ToJsonHttpResult()).Result as JsonHttpResult<string>;
         
         result!.StatusCode.Should().Be(200);
         result!.Value.Should().Be(value);
@@ -37,7 +37,7 @@ public class ToHttpResultT
         var value = "foo";
         
         var result = Result.Success(value)
-            .ToHttpResult(statusCode).Result as JsonHttpResult<string>;
+            .ToJsonHttpResult(statusCode).Result as JsonHttpResult<string>;
         
         result!.StatusCode.Should().Be(statusCode);
         result!.Value.Should().Be(value);
@@ -50,19 +50,19 @@ public class ToHttpResultT
         var value = "foo";
         
         var result = (await Task.FromResult(Result.Success(value))
-            .ToHttpResult(statusCode)).Result as JsonHttpResult<string>;
+            .ToJsonHttpResult(statusCode)).Result as JsonHttpResult<string>;
         
         result!.StatusCode.Should().Be(statusCode);
         result!.Value.Should().Be(value);
     }
     
     [Fact]
-    public void ResultT_Failure_can_be_mapped_to_HttpResult()
+    public void ResultT_Failure_can_be_mapped_to_JsonHttpResult()
     {
         var error = "Error";
         
         var result = Result.Failure<string>(error)
-            .ToHttpResult().Result as ProblemHttpResult;
+            .ToJsonHttpResult().Result as ProblemHttpResult;
         
         result!.StatusCode.Should().Be(400);
         result!.ProblemDetails.Status.Should().Be(400);
@@ -70,12 +70,12 @@ public class ToHttpResultT
     }
     
     [Fact]
-    public async Task ResultT_Failure_can_be_mapped_to_HttpResult_Async()
+    public async Task ResultT_Failure_can_be_mapped_to_JsonHttpResult_Async()
     {
         var error = "Error";
 
         var result = (await Task.FromResult(Result.Failure<string>(error))
-            .ToHttpResult()).Result as ProblemHttpResult;
+            .ToJsonHttpResult()).Result as ProblemHttpResult;
         
         result!.StatusCode.Should().Be(400);
         result!.ProblemDetails.Status.Should().Be(400);
@@ -89,7 +89,7 @@ public class ToHttpResultT
         var error = "Error";
         
         var result = Result.Failure<string>(error)
-            .ToHttpResult(failureStatusCode: statusCode).Result as ProblemHttpResult;
+            .ToJsonHttpResult(failureStatusCode: statusCode).Result as ProblemHttpResult;
         
         result!.StatusCode.Should().Be(statusCode);
         result!.ProblemDetails.Status.Should().Be(statusCode);
@@ -103,7 +103,7 @@ public class ToHttpResultT
         var error = "Error";
         
         var result = (await Task.FromResult(Result.Failure<string>(error))
-            .ToHttpResult(failureStatusCode: statusCode)).Result as ProblemHttpResult;
+            .ToJsonHttpResult(failureStatusCode: statusCode)).Result as ProblemHttpResult;
         
         result!.StatusCode.Should().Be(statusCode);
         result!.ProblemDetails.Status.Should().Be(statusCode);

--- a/CSharpFunctionalExtensions.HttpResults.Tests/ResultExtensions/ToJsonHttpResultTE.cs
+++ b/CSharpFunctionalExtensions.HttpResults.Tests/ResultExtensions/ToJsonHttpResultTE.cs
@@ -4,10 +4,10 @@ using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace CSharpFunctionalExtensions.HttpResults.Tests.ResultExtensions;
 
-public class ToHttpResultTE
+public class ToJsonHttpResultTE
 {
     [Fact]
-    public void ResultTE_Success_can_be_mapped_to_HttpResult()
+    public void ResultTE_Success_can_be_mapped_to_JsonHttpResult()
     {
         var document = new Document
         {
@@ -15,14 +15,14 @@ public class ToHttpResultTE
         };
         
         var result = Result.Success<Document, DocumentMissingError>(document)
-            .ToHttpResult().Result as JsonHttpResult<Document>;
+            .ToJsonHttpResult().Result as JsonHttpResult<Document>;
         
         result!.StatusCode.Should().Be(200);
         result!.Value!.DocumentId.Should().Be(document.DocumentId);
     }
     
     [Fact]
-    public async Task ResultTE_Success_can_be_mapped_to_HttpResult_Async()
+    public async Task ResultTE_Success_can_be_mapped_to_JsonHttpResult_Async()
     {
         var document = new Document
         {
@@ -30,7 +30,7 @@ public class ToHttpResultTE
         };
         
         var result = (await Task.FromResult(Result.Success<Document, DocumentMissingError>(document))
-            .ToHttpResult()).Result as JsonHttpResult<Document>;
+            .ToJsonHttpResult()).Result as JsonHttpResult<Document>;
         
         result!.StatusCode.Should().Be(200);
         result!.Value!.DocumentId.Should().Be(document.DocumentId);
@@ -46,7 +46,7 @@ public class ToHttpResultTE
         };
         
         var result = Result.Success<Document, DocumentMissingError>(document)
-            .ToHttpResult(statusCode).Result as JsonHttpResult<Document>;
+            .ToJsonHttpResult(statusCode).Result as JsonHttpResult<Document>;
         
         result!.StatusCode.Should().Be(statusCode);
     }
@@ -61,13 +61,13 @@ public class ToHttpResultTE
         };
         
         var result = (await Task.FromResult(Result.Success<Document, DocumentMissingError>(document))
-            .ToHttpResult(statusCode)).Result as JsonHttpResult<Document>;
+            .ToJsonHttpResult(statusCode)).Result as JsonHttpResult<Document>;
         
         result!.StatusCode.Should().Be(statusCode);
     }
     
     [Fact]
-    public void ResultTE_Failure_can_be_mapped_to_HttpResult()
+    public void ResultTE_Failure_can_be_mapped_to_JsonHttpResult()
     {
         var error = new DocumentMissingError
         {
@@ -75,14 +75,14 @@ public class ToHttpResultTE
         };
         
         var result = Result.Failure<Document, DocumentMissingError>(error)
-            .ToHttpResult().Result as NotFound<string>;
+            .ToJsonHttpResult().Result as NotFound<string>;
         
         result!.StatusCode.Should().Be(404);
         result!.Value.Should().Be(error.DocumentId);
     }
     
     [Fact]
-    public async Task ResultTE_Failure_can_be_mapped_to_HttpResult_Async()
+    public async Task ResultTE_Failure_can_be_mapped_to_JsonHttpResult_Async()
     {
         var error = new DocumentMissingError
         {
@@ -90,7 +90,7 @@ public class ToHttpResultTE
         };
         
         var result = (await Task.FromResult(Result.Failure<Document, DocumentMissingError>(error))
-            .ToHttpResult()).Result as NotFound<string>;
+            .ToJsonHttpResult()).Result as NotFound<string>;
         
         result!.StatusCode.Should().Be(404);
         result!.Value.Should().Be(error.DocumentId);

--- a/CSharpFunctionalExtensions.HttpResults.Tests/ResultExtensions/ToNoContentHttpResultT.cs
+++ b/CSharpFunctionalExtensions.HttpResults.Tests/ResultExtensions/ToNoContentHttpResultT.cs
@@ -12,7 +12,7 @@ public class ToNoContentHttpResultT
         var value = "foo";
         
         var result = Result.Success(value)
-            .ToNoContentHttpResult().Result as StatusCodeHttpResult;
+            .ToNoContentHttpResult().Result as NoContent;
         
         result!.StatusCode.Should().Be(204);
     }
@@ -23,33 +23,9 @@ public class ToNoContentHttpResultT
         var value = "foo";
         
         var result = (await Task.FromResult(Result.Success(value))
-            .ToNoContentHttpResult()).Result as StatusCodeHttpResult;
+            .ToNoContentHttpResult()).Result as NoContent;
         
         result!.StatusCode.Should().Be(204);
-    }
-    
-    [Fact]
-    public void ResultT_Success_StatusCode_can_be_changed()
-    {
-        var statusCode = 210;
-        var value = "foo";
-        
-        var result = Result.Success(value)
-            .ToNoContentHttpResult(statusCode).Result as StatusCodeHttpResult;
-        
-        result!.StatusCode.Should().Be(statusCode);
-    }
-    
-    [Fact]
-    public async Task ResultT_Success_StatusCode_can_be_changed_Async()
-    {
-        var statusCode = 210;
-        var value = "foo";
-        
-        var result = (await Task.FromResult(Result.Success(value))
-            .ToNoContentHttpResult(statusCode)).Result as StatusCodeHttpResult;
-        
-        result!.StatusCode.Should().Be(statusCode);
     }
     
     [Fact]

--- a/CSharpFunctionalExtensions.HttpResults.Tests/ResultExtensions/ToNoContentHttpResultTE.cs
+++ b/CSharpFunctionalExtensions.HttpResults.Tests/ResultExtensions/ToNoContentHttpResultTE.cs
@@ -13,7 +13,7 @@ public class ToNoContentHttpResultTE
         var value = "foo";
         
         var result = Result.Success<string, DocumentMissingError>(value)
-            .ToNoContentHttpResult().Result as StatusCodeHttpResult;
+            .ToNoContentHttpResult().Result as NoContent;
         
         result!.StatusCode.Should().Be(204);
     }
@@ -24,33 +24,9 @@ public class ToNoContentHttpResultTE
         var value = "foo";
         
         var result = (await Task.FromResult(Result.Success<string, DocumentMissingError>(value))
-            .ToNoContentHttpResult()).Result as StatusCodeHttpResult;
+            .ToNoContentHttpResult()).Result as NoContent;
         
         result!.StatusCode.Should().Be(204);
-    }
-    
-    [Fact]
-    public void ResultTE_Success_StatusCode_can_be_changed()
-    {
-        var statusCode = 210;
-        var value = "foo";
-        
-        var result = Result.Success<string, DocumentMissingError>(value)
-            .ToNoContentHttpResult(statusCode).Result as StatusCodeHttpResult;
-        
-        result!.StatusCode.Should().Be(statusCode);
-    }
-    
-    [Fact]
-    public async Task ResultTE_Success_StatusCode_can_be_changed_Async()
-    {
-        var statusCode = 210;
-        var value = "foo";
-        
-        var result = (await Task.FromResult(Result.Success<string, DocumentMissingError>(value))
-            .ToNoContentHttpResult(statusCode)).Result as StatusCodeHttpResult;
-        
-        result!.StatusCode.Should().Be(statusCode);
     }
     
     [Fact]

--- a/CSharpFunctionalExtensions.HttpResults.Tests/ResultExtensions/ToOkHttpResultT.cs
+++ b/CSharpFunctionalExtensions.HttpResults.Tests/ResultExtensions/ToOkHttpResultT.cs
@@ -1,0 +1,86 @@
+using CSharpFunctionalExtensions.HttpResults.ResultExtensions;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace CSharpFunctionalExtensions.HttpResults.Tests.ResultExtensions;
+
+public class ToOkHttpResultT
+{
+    [Fact]
+    public void ResultT_Success_can_be_mapped_to_OkHttpResult()
+    {
+        var value = "foo";
+        
+        var result = Result.Success(value)
+            .ToOkHttpResult().Result as Ok<string>;
+        
+        result!.StatusCode.Should().Be(200);
+        result!.Value.Should().Be(value);
+    }
+    
+    [Fact]
+    public async Task ResultT_Success_can_be_mapped_to_OkHttpResult_Async()
+    {
+        var value = "foo";
+        
+        var result = (await Task.FromResult(Result.Success(value))
+            .ToOkHttpResult()).Result as Ok<string>;
+        
+        result!.StatusCode.Should().Be(200);
+        result!.Value.Should().Be(value);
+    }
+    
+    [Fact]
+    public void ResultT_Failure_can_be_mapped_to_OkHttpResult()
+    {
+        var error = "Error";
+        
+        var result = Result.Failure<string>(error)
+            .ToOkHttpResult().Result as ProblemHttpResult;
+        
+        result!.StatusCode.Should().Be(400);
+        result!.ProblemDetails.Status.Should().Be(400);
+        result!.ProblemDetails.Detail.Should().Be(error);
+    }
+    
+    [Fact]
+    public async Task ResultT_Failure_can_be_mapped_to_OkHttpResult_Async()
+    {
+        var error = "Error";
+
+        var result = (await Task.FromResult(Result.Failure<string>(error))
+            .ToOkHttpResult()).Result as ProblemHttpResult;
+        
+        result!.StatusCode.Should().Be(400);
+        result!.ProblemDetails.Status.Should().Be(400);
+        result!.ProblemDetails.Detail.Should().Be(error);
+    }
+    
+    [Fact]
+    public void ResultT_Failure_StatusCode_can_be_changed()
+    {
+        var statusCode = 418;
+        var error = "Error";
+        
+        var result = Result.Failure<string>(error)
+            .ToOkHttpResult(failureStatusCode: statusCode).Result as ProblemHttpResult;
+        
+        result!.StatusCode.Should().Be(statusCode);
+        result!.ProblemDetails.Status.Should().Be(statusCode);
+        result!.ProblemDetails.Detail.Should().Be(error);
+    }
+    
+    [Fact]
+    public async Task ResultT_Failure_StatusCode_can_be_changed_Async()
+    {
+        var statusCode = 418;
+        var error = "Error";
+        
+        var result = (await Task.FromResult(Result.Failure<string>(error))
+            .ToOkHttpResult(failureStatusCode: statusCode)).Result as ProblemHttpResult;
+        
+        result!.StatusCode.Should().Be(statusCode);
+        result!.ProblemDetails.Status.Should().Be(statusCode);
+        result!.ProblemDetails.Detail.Should().Be(error);
+    }
+}

--- a/CSharpFunctionalExtensions.HttpResults.Tests/ResultExtensions/ToOkHttpResultTE.cs
+++ b/CSharpFunctionalExtensions.HttpResults.Tests/ResultExtensions/ToOkHttpResultTE.cs
@@ -1,0 +1,68 @@
+﻿using CSharpFunctionalExtensions.HttpResults.Tests.Shared;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace CSharpFunctionalExtensions.HttpResults.Tests.ResultExtensions;
+
+public class ToOkHttpResultTE
+{
+    [Fact]
+    public void ResultTE_Success_can_be_mapped_to_OkHttpResult()
+    {
+        var document = new Document
+        {
+            DocumentId = Guid.NewGuid().ToString()
+        };
+        
+        var result = Result.Success<Document, DocumentMissingError>(document)
+            .ToOkHttpResult().Result as Ok<Document>;
+        
+        result!.StatusCode.Should().Be(200);
+        result!.Value!.DocumentId.Should().Be(document.DocumentId);
+    }
+    
+    [Fact]
+    public async Task ResultTE_Success_can_be_mapped_to_OkHttpResult_Async()
+    {
+        var document = new Document
+        {
+            DocumentId = Guid.NewGuid().ToString()
+        };
+        
+        var result = (await Task.FromResult(Result.Success<Document, DocumentMissingError>(document))
+            .ToOkHttpResult()).Result as Ok<Document>;
+        
+        result!.StatusCode.Should().Be(200);
+        result!.Value!.DocumentId.Should().Be(document.DocumentId);
+    }
+    
+    [Fact]
+    public void ResultTE_Failure_can_be_mapped_to_OkHttpResult()
+    {
+        var error = new DocumentMissingError
+        {
+            DocumentId = Guid.NewGuid().ToString()
+        };
+        
+        var result = Result.Failure<Document, DocumentMissingError>(error)
+            .ToOkHttpResult().Result as NotFound<string>;
+        
+        result!.StatusCode.Should().Be(404);
+        result!.Value.Should().Be(error.DocumentId);
+    }
+    
+    [Fact]
+    public async Task ResultTE_Failure_can_be_mapped_to_OkHttpResult_Async()
+    {
+        var error = new DocumentMissingError
+        {
+            DocumentId = Guid.NewGuid().ToString()
+        };
+        
+        var result = (await Task.FromResult(Result.Failure<Document, DocumentMissingError>(error))
+            .ToOkHttpResult()).Result as NotFound<string>;
+        
+        result!.StatusCode.Should().Be(404);
+        result!.Value.Should().Be(error.DocumentId);
+    }
+}

--- a/CSharpFunctionalExtensions.HttpResults.Tests/ResultExtensions/ToStatusCodeHttpResult.cs
+++ b/CSharpFunctionalExtensions.HttpResults.Tests/ResultExtensions/ToStatusCodeHttpResult.cs
@@ -4,22 +4,22 @@ using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace CSharpFunctionalExtensions.HttpResults.Tests.ResultExtensions;
 
-public class ToHttpResult
+public class ToStatusCodeHttpResult
 {
     [Fact]
-    public void Result_Success_can_be_mapped_to_HttpResult()
+    public void Result_Success_can_be_mapped_to_StatusCodeHttpResult()
     {
         var result = Result.Success()
-            .ToHttpResult().Result as StatusCodeHttpResult;
+            .ToStatusCodeHttpResult().Result as StatusCodeHttpResult;
         
         result!.StatusCode.Should().Be(204);
     }
     
     [Fact]
-    public async Task Result_Success_can_be_mapped_to_HttpResult_Async()
+    public async Task Result_Success_can_be_mapped_to_StatusCodeHttpResult_Async()
     {
         var result = (await Task.FromResult(Result.Success())
-            .ToHttpResult()).Result as StatusCodeHttpResult;
+            .ToStatusCodeHttpResult()).Result as StatusCodeHttpResult;
         
         result!.StatusCode.Should().Be(204);
     }
@@ -30,7 +30,7 @@ public class ToHttpResult
         var statusCode = 210;
         
         var result = Result.Success()
-            .ToHttpResult(statusCode).Result as StatusCodeHttpResult;
+            .ToStatusCodeHttpResult(statusCode).Result as StatusCodeHttpResult;
         
         result!.StatusCode.Should().Be(statusCode);
     }
@@ -41,18 +41,18 @@ public class ToHttpResult
         var statusCode = 210;
         
         var result = (await Task.FromResult(Result.Success())
-            .ToHttpResult(statusCode)).Result as StatusCodeHttpResult;
+            .ToStatusCodeHttpResult(statusCode)).Result as StatusCodeHttpResult;
         
         result!.StatusCode.Should().Be(statusCode);
     }
     
     [Fact]
-    public void Result_Failure_can_be_mapped_to_HttpResult()
+    public void Result_Failure_can_be_mapped_to_StatusCodeHttpResult()
     {
         var error = "Error";
         
         var result = Result.Failure(error)
-            .ToHttpResult().Result as ProblemHttpResult;
+            .ToStatusCodeHttpResult().Result as ProblemHttpResult;
         
         result!.StatusCode.Should().Be(400);
         result!.ProblemDetails.Status.Should().Be(400);
@@ -60,12 +60,12 @@ public class ToHttpResult
     }
     
     [Fact]
-    public async Task Result_Failure_can_be_mapped_to_HttpResult_Async()
+    public async Task Result_Failure_can_be_mapped_to_StatusCodeHttpResult_Async()
     {
         var error = "Error";
 
         var result = (await Task.FromResult(Result.Failure(error))
-            .ToHttpResult()).Result as ProblemHttpResult;
+            .ToStatusCodeHttpResult()).Result as ProblemHttpResult;
         
         result!.StatusCode.Should().Be(400);
         result!.ProblemDetails.Status.Should().Be(400);
@@ -79,7 +79,7 @@ public class ToHttpResult
         var error = "Error";
         
         var result = Result.Failure(error)
-            .ToHttpResult(failureStatusCode: statusCode).Result as ProblemHttpResult;
+            .ToStatusCodeHttpResult(failureStatusCode: statusCode).Result as ProblemHttpResult;
         
         result!.StatusCode.Should().Be(statusCode);
         result!.ProblemDetails.Status.Should().Be(statusCode);
@@ -93,7 +93,7 @@ public class ToHttpResult
         var error = "Error";
         
         var result = (await Task.FromResult(Result.Failure(error))
-            .ToHttpResult(failureStatusCode: statusCode)).Result as ProblemHttpResult;
+            .ToStatusCodeHttpResult(failureStatusCode: statusCode)).Result as ProblemHttpResult;
         
         result!.StatusCode.Should().Be(statusCode);
         result!.ProblemDetails.Status.Should().Be(statusCode);

--- a/CSharpFunctionalExtensions.HttpResults.Tests/ResultExtensions/ToStatusCodeHttpResultT.cs
+++ b/CSharpFunctionalExtensions.HttpResults.Tests/ResultExtensions/ToStatusCodeHttpResultT.cs
@@ -1,0 +1,108 @@
+using CSharpFunctionalExtensions.HttpResults.ResultExtensions;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace CSharpFunctionalExtensions.HttpResults.Tests.ResultExtensions;
+
+public class ToStatusCodeHttpResultT
+{
+    [Fact]
+    public void ResultT_Success_can_be_mapped_to_StatusCodeHttpResult()
+    {
+        var value = "foo";
+        
+        var result = Result.Success(value)
+            .ToStatusCodeHttpResult().Result as StatusCodeHttpResult;
+        
+        result!.StatusCode.Should().Be(204);
+    }
+    
+    [Fact]
+    public async Task ResultT_Success_can_be_mapped_to_StatusCodeHttpResult_Async()
+    {
+        var value = "foo";
+        
+        var result = (await Task.FromResult(Result.Success(value))
+            .ToStatusCodeHttpResult()).Result as StatusCodeHttpResult;
+        
+        result!.StatusCode.Should().Be(204);
+    }
+    
+    [Fact]
+    public void ResultT_Success_StatusCode_can_be_changed()
+    {
+        var statusCode = 210;
+        var value = "foo";
+        
+        var result = Result.Success(value)
+            .ToStatusCodeHttpResult(statusCode).Result as StatusCodeHttpResult;
+        
+        result!.StatusCode.Should().Be(statusCode);
+    }
+    
+    [Fact]
+    public async Task ResultT_Success_StatusCode_can_be_changed_Async()
+    {
+        var statusCode = 210;
+        var value = "foo";
+        
+        var result = (await Task.FromResult(Result.Success(value))
+            .ToStatusCodeHttpResult(statusCode)).Result as StatusCodeHttpResult;
+        
+        result!.StatusCode.Should().Be(statusCode);
+    }
+    
+    [Fact]
+    public void ResultT_Failure_can_be_mapped_to_HttpResult()
+    {
+        var error = "Error";
+        
+        var result = Result.Failure<string>(error)
+            .ToStatusCodeHttpResult().Result as ProblemHttpResult;
+        
+        result!.StatusCode.Should().Be(400);
+        result!.ProblemDetails.Status.Should().Be(400);
+        result!.ProblemDetails.Detail.Should().Be(error);
+    }
+    
+    [Fact]
+    public async Task ResultT_Failure_can_be_mapped_to_StatusCodeHttpResult_Async()
+    {
+        var error = "Error";
+
+        var result = (await Task.FromResult(Result.Failure<string>(error))
+            .ToStatusCodeHttpResult()).Result as ProblemHttpResult;
+        
+        result!.StatusCode.Should().Be(400);
+        result!.ProblemDetails.Status.Should().Be(400);
+        result!.ProblemDetails.Detail.Should().Be(error);
+    }
+    
+    [Fact]
+    public void ResultT_Failure_StatusCode_can_be_changed()
+    {
+        var statusCode = 418;
+        var error = "Error";
+        
+        var result = Result.Failure<string>(error)
+            .ToStatusCodeHttpResult(failureStatusCode: statusCode).Result as ProblemHttpResult;
+        
+        result!.StatusCode.Should().Be(statusCode);
+        result!.ProblemDetails.Status.Should().Be(statusCode);
+        result!.ProblemDetails.Detail.Should().Be(error);
+    }
+    
+    [Fact]
+    public async Task ResultT_Failure_StatusCode_can_be_changed_Async()
+    {
+        var statusCode = 418;
+        var error = "Error";
+        
+        var result = (await Task.FromResult(Result.Failure<string>(error))
+            .ToStatusCodeHttpResult(failureStatusCode: statusCode)).Result as ProblemHttpResult;
+        
+        result!.StatusCode.Should().Be(statusCode);
+        result!.ProblemDetails.Status.Should().Be(statusCode);
+        result!.ProblemDetails.Detail.Should().Be(error);
+    }
+}

--- a/CSharpFunctionalExtensions.HttpResults.Tests/ResultExtensions/ToStatusCodeHttpResultTE.cs
+++ b/CSharpFunctionalExtensions.HttpResults.Tests/ResultExtensions/ToStatusCodeHttpResultTE.cs
@@ -1,0 +1,84 @@
+using CSharpFunctionalExtensions.HttpResults.Tests.Shared;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace CSharpFunctionalExtensions.HttpResults.Tests.ResultExtensions;
+
+public class ToStatusCodeHttpResultTE
+{
+    [Fact]
+    public void ResultTE_Success_can_be_mapped_to_StatusCodeHttpResult()
+    {
+        var value = "foo";
+        
+        var result = Result.Success<string, DocumentMissingError>(value)
+            .ToStatusCodeHttpResult().Result as StatusCodeHttpResult;
+        
+        result!.StatusCode.Should().Be(204);
+    }
+    
+    [Fact]
+    public async Task ResultTE_Success_can_be_mapped_to_StatusCodeHttpResult_Async()
+    {
+        var value = "foo";
+        
+        var result = (await Task.FromResult(Result.Success<string, DocumentMissingError>(value))
+            .ToStatusCodeHttpResult()).Result as StatusCodeHttpResult;
+        
+        result!.StatusCode.Should().Be(204);
+    }
+    
+    [Fact]
+    public void ResultTE_Success_StatusCode_can_be_changed()
+    {
+        var statusCode = 210;
+        var value = "foo";
+        
+        var result = Result.Success<string, DocumentMissingError>(value)
+            .ToStatusCodeHttpResult(statusCode).Result as StatusCodeHttpResult;
+        
+        result!.StatusCode.Should().Be(statusCode);
+    }
+    
+    [Fact]
+    public async Task ResultTE_Success_StatusCode_can_be_changed_Async()
+    {
+        var statusCode = 210;
+        var value = "foo";
+        
+        var result = (await Task.FromResult(Result.Success<string, DocumentMissingError>(value))
+            .ToStatusCodeHttpResult(statusCode)).Result as StatusCodeHttpResult;
+        
+        result!.StatusCode.Should().Be(statusCode);
+    }
+    
+    [Fact]
+    public void ResultTE_Failure_can_be_mapped_to_HttpResult()
+    {
+        var error = new DocumentMissingError
+        {
+            DocumentId = Guid.NewGuid().ToString()
+        };
+        
+        var result = Result.Failure<string, DocumentMissingError>(error)
+            .ToStatusCodeHttpResult().Result as NotFound<string>;
+        
+        result!.StatusCode.Should().Be(404);
+        result!.Value.Should().Be(error.DocumentId);
+    }
+    
+    [Fact]
+    public async Task ResultTE_Failure_can_be_mapped_to_StatusCodeHttpResult_Async()
+    {
+        var error = new DocumentMissingError
+        {
+            DocumentId = Guid.NewGuid().ToString()
+        };
+
+        var result = (await Task.FromResult(Result.Failure<string, DocumentMissingError>(error))
+            .ToStatusCodeHttpResult()).Result as NotFound<string>;
+        
+        result!.StatusCode.Should().Be(404);
+        result!.Value.Should().Be(error.DocumentId);
+    }
+}

--- a/CSharpFunctionalExtensions.HttpResults/ResultExtensions/ToJsonHttpResultT.cs
+++ b/CSharpFunctionalExtensions.HttpResults/ResultExtensions/ToJsonHttpResultT.cs
@@ -12,7 +12,7 @@ public static partial class ResultExtensions
     /// <summary>
     /// Returns a <see cref="JsonHttpResult{TValue}"/> in case of success result. Returns <see cref="ProblemHttpResult"/> in case of failure. You can override the success and error status code.
     /// </summary>
-    public static Results<JsonHttpResult<T>, ProblemHttpResult> ToHttpResult<T>(this Result<T> result, int successStatusCode = 200, int failureStatusCode = 400)
+    public static Results<JsonHttpResult<T>, ProblemHttpResult> ToJsonHttpResult<T>(this Result<T> result, int successStatusCode = 200, int failureStatusCode = 400)
     {
         if (result.IsSuccess) return TypedResults.Json(result.Value, statusCode: successStatusCode);
         
@@ -31,8 +31,8 @@ public static partial class ResultExtensions
     /// <summary>
     /// Returns a <see cref="JsonHttpResult{TValue}"/> in case of success result. Returns <see cref="ProblemHttpResult"/> in case of failure. You can override the success and error status code.
     /// </summary>
-    public static async Task<Results<JsonHttpResult<T>, ProblemHttpResult>> ToHttpResult<T>(this Task<Result<T>> result, int successStatusCode = 200, int failureStatusCode = 400)
+    public static async Task<Results<JsonHttpResult<T>, ProblemHttpResult>> ToJsonHttpResult<T>(this Task<Result<T>> result, int successStatusCode = 200, int failureStatusCode = 400)
     {
-        return (await result).ToHttpResult(successStatusCode, failureStatusCode);
+        return (await result).ToJsonHttpResult(successStatusCode, failureStatusCode);
     }
 }

--- a/CSharpFunctionalExtensions.HttpResults/ResultExtensions/ToNoContentHttpResultT.cs
+++ b/CSharpFunctionalExtensions.HttpResults/ResultExtensions/ToNoContentHttpResultT.cs
@@ -10,11 +10,11 @@ namespace CSharpFunctionalExtensions.HttpResults.ResultExtensions;
 public static partial class ResultExtensions
 {
     /// <summary>
-    /// Discards the value of <see cref="Result{T}"/> and Returns a <see cref="StatusCodeHttpResult"/> in case of success result. Returns <see cref="ProblemHttpResult"/> in case of failure. You can override the success and error status code.
+    /// Discards the value of <see cref="Result{T}"/> and Returns a <see cref="NoContent"/> in case of success result. Returns <see cref="ProblemHttpResult"/> in case of failure. You can override the error status code.
     /// </summary>
-    public static Results<StatusCodeHttpResult, ProblemHttpResult> ToNoContentHttpResult<T>(this Result<T> result, int successStatusCode = 204, int failureStatusCode = 400)
+    public static Results<NoContent, ProblemHttpResult> ToNoContentHttpResult<T>(this Result<T> result, int failureStatusCode = 400)
     {
-        if (result.IsSuccess) return TypedResults.StatusCode(successStatusCode);
+        if (result.IsSuccess) return TypedResults.NoContent();
         
         var problemDetailsInfo = ProblemDetailsMap.Find(failureStatusCode);
         var problemDetails = new ProblemDetails
@@ -29,10 +29,10 @@ public static partial class ResultExtensions
     }
     
     /// <summary>
-    /// Discards the value of <see cref="Result{T}"/> and Returns a <see cref="StatusCodeHttpResult"/> in case of success result. Returns <see cref="ProblemHttpResult"/> in case of failure. You can override the success and error status code.
+    /// Discards the value of <see cref="Result{T}"/> and Returns a <see cref="NoContent"/> in case of success result. Returns <see cref="ProblemHttpResult"/> in case of failure. You can override the error status code.
     /// </summary>
-    public static async Task<Results<StatusCodeHttpResult, ProblemHttpResult>> ToNoContentHttpResult<T>(this Task<Result<T>> result, int successStatusCode = 204, int failureStatusCode = 400)
+    public static async Task<Results<NoContent, ProblemHttpResult>> ToNoContentHttpResult<T>(this Task<Result<T>> result, int failureStatusCode = 400)
     {
-        return (await result).ToNoContentHttpResult(successStatusCode, failureStatusCode);
+        return (await result).ToNoContentHttpResult(failureStatusCode);
     }
 }

--- a/CSharpFunctionalExtensions.HttpResults/ResultExtensions/ToOkHttpResultT.cs
+++ b/CSharpFunctionalExtensions.HttpResults/ResultExtensions/ToOkHttpResultT.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+
+namespace CSharpFunctionalExtensions.HttpResults.ResultExtensions;
+
+/// <summary>
+/// Extension methods for <see cref="Result{T}"/>
+/// </summary>
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Returns a <see cref="Ok{TValue}"/> in case of success result. Returns <see cref="ProblemHttpResult"/> in case of failure. You can override the error status code.
+    /// </summary>
+    public static Results<Ok<T>, ProblemHttpResult> ToOkHttpResult<T>(this Result<T> result, int failureStatusCode = 400)
+    {
+        if (result.IsSuccess) return TypedResults.Ok(result.Value);
+        
+        var problemDetailsInfo = ProblemDetailsMap.Find(failureStatusCode);
+        var problemDetails = new ProblemDetails
+        {
+            Status = failureStatusCode,
+            Title = problemDetailsInfo.Title,
+            Type = problemDetailsInfo.Type,
+            Detail = result.Error
+        };
+        
+        return TypedResults.Problem(problemDetails);
+    }
+    
+    /// <summary>
+    /// Returns a <see cref="Ok{TValue}"/> in case of success result. Returns <see cref="ProblemHttpResult"/> in case of failure. You can override the error status code.
+    /// </summary>
+    public static async Task<Results<Ok<T>, ProblemHttpResult>> ToOkHttpResult<T>(this Task<Result<T>> result, int failureStatusCode = 400)
+    {
+        return (await result).ToOkHttpResult(failureStatusCode);
+    }
+}

--- a/CSharpFunctionalExtensions.HttpResults/ResultExtensions/ToStatusCodeHttpResult.cs
+++ b/CSharpFunctionalExtensions.HttpResults/ResultExtensions/ToStatusCodeHttpResult.cs
@@ -12,7 +12,7 @@ public static partial class ResultExtensions
     /// <summary>
     /// Returns a <see cref="StatusCodeHttpResult"/> in case of success result. Returns <see cref="ProblemHttpResult"/> in case of failure. You can override the success and error status code.
     /// </summary>
-    public static Results<StatusCodeHttpResult, ProblemHttpResult> ToHttpResult(this Result result, int successStatusCode = 204, int failureStatusCode = 400)
+    public static Results<StatusCodeHttpResult, ProblemHttpResult> ToStatusCodeHttpResult(this Result result, int successStatusCode = 204, int failureStatusCode = 400)
     {
         if (result.IsSuccess) return TypedResults.StatusCode(successStatusCode);
         
@@ -31,8 +31,8 @@ public static partial class ResultExtensions
     /// <summary>
     /// Returns a <see cref="StatusCodeHttpResult"/> in case of success result. Returns <see cref="ProblemHttpResult"/> in case of failure. You can override the success and error status code.
     /// </summary>
-    public static async Task<Results<StatusCodeHttpResult, ProblemHttpResult>> ToHttpResult(this Task<Result> result, int successStatusCode = 204, int failureStatusCode = 400)
+    public static async Task<Results<StatusCodeHttpResult, ProblemHttpResult>> ToStatusCodeHttpResult(this Task<Result> result, int successStatusCode = 204, int failureStatusCode = 400)
     {
-        return (await result).ToHttpResult(successStatusCode, failureStatusCode);
+        return (await result).ToStatusCodeHttpResult(successStatusCode, failureStatusCode);
     }
 }

--- a/CSharpFunctionalExtensions.HttpResults/ResultExtensions/ToStatusCodeHttpResultT.cs
+++ b/CSharpFunctionalExtensions.HttpResults/ResultExtensions/ToStatusCodeHttpResultT.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+
+namespace CSharpFunctionalExtensions.HttpResults.ResultExtensions;
+
+/// <summary>
+/// Extension methods for <see cref="Result{T}"/>
+/// </summary>
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Discards the value of <see cref="Result{T}"/> and Returns a <see cref="StatusCodeHttpResult"/> in case of success result. Returns <see cref="ProblemHttpResult"/> in case of failure. You can override the success and error status code.
+    /// </summary>
+    public static Results<StatusCodeHttpResult, ProblemHttpResult> ToStatusCodeHttpResult<T>(this Result<T> result, int successStatusCode = 204, int failureStatusCode = 400)
+    {
+        if (result.IsSuccess) return TypedResults.StatusCode(successStatusCode);
+        
+        var problemDetailsInfo = ProblemDetailsMap.Find(failureStatusCode);
+        var problemDetails = new ProblemDetails
+        {
+            Status = failureStatusCode,
+            Title = problemDetailsInfo.Title,
+            Type = problemDetailsInfo.Type,
+            Detail = result.Error
+        };
+        
+        return TypedResults.Problem(problemDetails);
+    }
+    
+    /// <summary>
+    /// Discards the value of <see cref="Result{T}"/> and Returns a <see cref="StatusCodeHttpResult"/> in case of success result. Returns <see cref="ProblemHttpResult"/> in case of failure. You can override the success and error status code.
+    /// </summary>
+    public static async Task<Results<StatusCodeHttpResult, ProblemHttpResult>> ToStatusCodeHttpResult<T>(this Task<Result<T>> result, int successStatusCode = 204, int failureStatusCode = 400)
+    {
+        return (await result).ToStatusCodeHttpResult(successStatusCode, failureStatusCode);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ These methods are available:
 | Method                                | Short Description                                                                             |
 |---------------------------------------|-----------------------------------------------------------------------------------------------|
 | `.ToStatusCodeHttpResult()`           | Returns `StatusCodeHttpResult` or `ProblemHttpResult`                                         |
+| `.ToStatusCodeHttpResult<T>()`        | Returns `StatusCodeHttpResult` or `ProblemHttpResult`                                         |
 | `.ToHttpResult<T>()`                  | Returns `JsonHttpResult<T>` or `ProblemHttpResult`                                            |
 | `.ToHttpResult<T,E>()`                | Returns `JsonHttpResult<T>` or custom error                                                   |
 | `.ToNoContentHttpResult<T>()`         | Discards value of `Result<T>` and returns empty `StatusCodeHttpResult` or `ProblemHttpResult` |

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ These methods are available:
 | `.ToJsonHttpResult<T>()`              | Returns `JsonHttpResult<T>` or `ProblemHttpResult`                           |
 | `.ToJsonHttpResult<T,E>()`            | Returns `JsonHttpResult<T>` or custom error                                  |
 | `.ToOkHttpResult<T>()`                | Returns `Ok<T>` or `ProblemHttpResult`                                       |
+| `.ToOkHttpResult<T,E>()`              | Returns `Ok<T>` or custom error                                              |
 | `.ToNoContentHttpResult<T>()`         | Discards value of `Result<T>` and returns `NoContent` or `ProblemHttpResult` |
 | `.ToNoContentHttpResult<T,E>()`       | Discards value of `Result<T>` and returns `NoContent` or custom error        |
 | `.ToCreatedHttpResult<T>()`           | Returns `Created<T>` or `ProblemHttpResult`                                  |

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ These methods are available:
 | `.ToStatusCodeHttpResult()`           | Returns `StatusCodeHttpResult` or `ProblemHttpResult`                                         |
 | `.ToStatusCodeHttpResult<T>()`        | Returns `StatusCodeHttpResult` or `ProblemHttpResult`                                         |
 | `.ToStatusCodeHttpResult<T,E>()`      | Returns `StatusCodeHttpResult` or custom error                                                |
-| `.ToHttpResult<T>()`                  | Returns `JsonHttpResult<T>` or `ProblemHttpResult`                                            |
+| `.ToJsonHttpResult<T>()`              | Returns `JsonHttpResult<T>` or `ProblemHttpResult`                                            |
 | `.ToHttpResult<T,E>()`                | Returns `JsonHttpResult<T>` or custom error                                                   |
 | `.ToNoContentHttpResult<T>()`         | Discards value of `Result<T>` and returns empty `StatusCodeHttpResult` or `ProblemHttpResult` |
 | `.ToNoContentHttpResult<T,E>()`       | Discards value of `Result<T>` and returns empty `StatusCodeHttpResult` or custom error        |

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ These methods are available:
 | `.ToStatusCodeHttpResult<T,E>()`      | Returns `StatusCodeHttpResult` or custom error                               |
 | `.ToJsonHttpResult<T>()`              | Returns `JsonHttpResult<T>` or `ProblemHttpResult`                           |
 | `.ToJsonHttpResult<T,E>()`            | Returns `JsonHttpResult<T>` or custom error                                  |
+| `.ToOkHttpResult<T>()`                | Returns `Ok<T>` or `ProblemHttpResult`                                       |
 | `.ToNoContentHttpResult<T>()`         | Discards value of `Result<T>` and returns `NoContent` or `ProblemHttpResult` |
 | `.ToNoContentHttpResult<T,E>()`       | Discards value of `Result<T>` and returns `NoContent` or custom error        |
 | `.ToCreatedHttpResult<T>()`           | Returns `Created<T>` or `ProblemHttpResult`                                  |

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ These methods are available:
 
 | Method                                | Short Description                                                                             |
 |---------------------------------------|-----------------------------------------------------------------------------------------------|
-| `.ToHttpResult()`                     | Returns `StatusCodeHttpResult` or `ProblemHttpResult`                                         |
+| `.ToStatusCodeHttpResult()`           | Returns `StatusCodeHttpResult` or `ProblemHttpResult`                                         |
 | `.ToHttpResult<T>()`                  | Returns `JsonHttpResult<T>` or `ProblemHttpResult`                                            |
 | `.ToHttpResult<T,E>()`                | Returns `JsonHttpResult<T>` or custom error                                                   |
 | `.ToNoContentHttpResult<T>()`         | Discards value of `Result<T>` and returns empty `StatusCodeHttpResult` or `ProblemHttpResult` |

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ This library uses a Source Generator to generate extension methods for your own 
     ```csharp
     app.MapGet("/users/{id}", (string id) => {
         return userRepository.Find(id) //Result<User,UserNotFoundError>
-            .ToHttpResult(); //returns 200 with User as payload or 404 with ProblemDetails object defined above
+            .ToOkHttpResult(); //returns 200 with User as payload or 404 with ProblemDetails object defined above
     });
     ```
 

--- a/README.md
+++ b/README.md
@@ -33,27 +33,27 @@ This library provides you extension methods to map the following types to `HttpR
 
 These methods are available:
 
-| Method                                | Short Description                                                                      |
-|---------------------------------------|----------------------------------------------------------------------------------------|
-| `.ToStatusCodeHttpResult()`           | Returns `StatusCodeHttpResult` or `ProblemHttpResult`                                  |
-| `.ToStatusCodeHttpResult<T>()`        | Returns `StatusCodeHttpResult` or `ProblemHttpResult`                                  |
-| `.ToStatusCodeHttpResult<T,E>()`      | Returns `StatusCodeHttpResult` or custom error                                         |
-| `.ToJsonHttpResult<T>()`              | Returns `JsonHttpResult<T>` or `ProblemHttpResult`                                     |
-| `.ToJsonHttpResult<T,E>()`            | Returns `JsonHttpResult<T>` or custom error                                            |
-| `.ToNoContentHttpResult<T>()`         | Discards value of `Result<T>` and returns `NoContent` or `ProblemHttpResult`           |
-| `.ToNoContentHttpResult<T,E>()`       | Discards value of `Result<T>` and returns empty `StatusCodeHttpResult` or custom error |
-| `.ToCreatedHttpResult<T>()`           | Returns `Created<T>` or `ProblemHttpResult`                                            |
-| `.ToCreatedHttpResult<T,E>()`         | Returns `Created<T>` or custom error                                                   |
-| `.ToCreatedAtRouteHttpResult<T>()`    | Returns `CreatedAtRoute<T>` or `ProblemHttpResult`                                     |
-| `.ToCreatedAtRouteHttpResult<T,E>()`  | Returns `CreatedAtRoute<T>` or custom error                                            |
-| `.ToAcceptedHttpResult<T>()`          | Returns `Accepted<T>` or `ProblemHttpResult`                                           |
-| `.ToAcceptedHttpResult<T,E>()`        | Returns `Accepted<T>` or custom error                                                  |
-| `.ToAcceptedAtRouteHttpResult<T>()`   | Returns `AcceptedAtRoute<T>` or `ProblemHttpResult`                                    |
-| `.ToAcceptedAtRouteHttpResult<T,E>()` | Returns `AcceptedAtRoute<T>` or custom error                                           |
-| `.ToFileHttpResult<byte[]>()`         | Returns `FileContentHttpResult` or `ProblemHttpResult`                                 |
-| `.ToFileHttpResult<byte[],E>()`       | Returns `FileContentHttpResult` or custom error                                        |
-| `.ToFileStreamHttpResult<Stream>()`   | Returns `FileStreamHttpResult` or `ProblemHttpResult`                                  |
-| `.ToFileStreamHttpResult<Stream,E>()` | Returns `FileStreamHttpResult` or custom error                                         |
+| Method                                | Short Description                                                            |
+|---------------------------------------|------------------------------------------------------------------------------|
+| `.ToStatusCodeHttpResult()`           | Returns `StatusCodeHttpResult` or `ProblemHttpResult`                        |
+| `.ToStatusCodeHttpResult<T>()`        | Returns `StatusCodeHttpResult` or `ProblemHttpResult`                        |
+| `.ToStatusCodeHttpResult<T,E>()`      | Returns `StatusCodeHttpResult` or custom error                               |
+| `.ToJsonHttpResult<T>()`              | Returns `JsonHttpResult<T>` or `ProblemHttpResult`                           |
+| `.ToJsonHttpResult<T,E>()`            | Returns `JsonHttpResult<T>` or custom error                                  |
+| `.ToNoContentHttpResult<T>()`         | Discards value of `Result<T>` and returns `NoContent` or `ProblemHttpResult` |
+| `.ToNoContentHttpResult<T,E>()`       | Discards value of `Result<T>` and returns `NoContent` or custom error        |
+| `.ToCreatedHttpResult<T>()`           | Returns `Created<T>` or `ProblemHttpResult`                                  |
+| `.ToCreatedHttpResult<T,E>()`         | Returns `Created<T>` or custom error                                         |
+| `.ToCreatedAtRouteHttpResult<T>()`    | Returns `CreatedAtRoute<T>` or `ProblemHttpResult`                           |
+| `.ToCreatedAtRouteHttpResult<T,E>()`  | Returns `CreatedAtRoute<T>` or custom error                                  |
+| `.ToAcceptedHttpResult<T>()`          | Returns `Accepted<T>` or `ProblemHttpResult`                                 |
+| `.ToAcceptedHttpResult<T,E>()`        | Returns `Accepted<T>` or custom error                                        |
+| `.ToAcceptedAtRouteHttpResult<T>()`   | Returns `AcceptedAtRoute<T>` or `ProblemHttpResult`                          |
+| `.ToAcceptedAtRouteHttpResult<T,E>()` | Returns `AcceptedAtRoute<T>` or custom error                                 |
+| `.ToFileHttpResult<byte[]>()`         | Returns `FileContentHttpResult` or `ProblemHttpResult`                       |
+| `.ToFileHttpResult<byte[],E>()`       | Returns `FileContentHttpResult` or custom error                              |
+| `.ToFileStreamHttpResult<Stream>()`   | Returns `FileStreamHttpResult` or `ProblemHttpResult`                        |
+| `.ToFileStreamHttpResult<Stream,E>()` | Returns `FileStreamHttpResult` or custom error                               |
 
 For almost every method you can override the default status codes for Success/Failure.
 

--- a/README.md
+++ b/README.md
@@ -33,27 +33,27 @@ This library provides you extension methods to map the following types to `HttpR
 
 These methods are available:
 
-| Method                                | Short Description                                                                             |
-|---------------------------------------|-----------------------------------------------------------------------------------------------|
-| `.ToStatusCodeHttpResult()`           | Returns `StatusCodeHttpResult` or `ProblemHttpResult`                                         |
-| `.ToStatusCodeHttpResult<T>()`        | Returns `StatusCodeHttpResult` or `ProblemHttpResult`                                         |
-| `.ToStatusCodeHttpResult<T,E>()`      | Returns `StatusCodeHttpResult` or custom error                                                |
-| `.ToJsonHttpResult<T>()`              | Returns `JsonHttpResult<T>` or `ProblemHttpResult`                                            |
-| `.ToJsonHttpResult<T,E>()`            | Returns `JsonHttpResult<T>` or custom error                                                   |
-| `.ToNoContentHttpResult<T>()`         | Discards value of `Result<T>` and returns empty `StatusCodeHttpResult` or `ProblemHttpResult` |
-| `.ToNoContentHttpResult<T,E>()`       | Discards value of `Result<T>` and returns empty `StatusCodeHttpResult` or custom error        |
-| `.ToCreatedHttpResult<T>()`           | Returns `Created<T>` or `ProblemHttpResult`                                                   |
-| `.ToCreatedHttpResult<T,E>()`         | Returns `Created<T>` or custom error                                                          |
-| `.ToCreatedAtRouteHttpResult<T>()`    | Returns `CreatedAtRoute<T>` or `ProblemHttpResult`                                            |
-| `.ToCreatedAtRouteHttpResult<T,E>()`  | Returns `CreatedAtRoute<T>` or custom error                                                   |
-| `.ToAcceptedHttpResult<T>()`          | Returns `Accepted<T>` or `ProblemHttpResult`                                                  |
-| `.ToAcceptedHttpResult<T,E>()`        | Returns `Accepted<T>` or custom error                                                         |
-| `.ToAcceptedAtRouteHttpResult<T>()`   | Returns `AcceptedAtRoute<T>` or `ProblemHttpResult`                                           |
-| `.ToAcceptedAtRouteHttpResult<T,E>()` | Returns `AcceptedAtRoute<T>` or custom error                                                  |
-| `.ToFileHttpResult<byte[]>()`         | Returns `FileContentHttpResult` or `ProblemHttpResult`                                        |
-| `.ToFileHttpResult<byte[],E>()`       | Returns `FileContentHttpResult` or custom error                                               |
-| `.ToFileStreamHttpResult<Stream>()`   | Returns `FileStreamHttpResult` or `ProblemHttpResult`                                         |
-| `.ToFileStreamHttpResult<Stream,E>()` | Returns `FileStreamHttpResult` or custom error                                                |
+| Method                                | Short Description                                                                      |
+|---------------------------------------|----------------------------------------------------------------------------------------|
+| `.ToStatusCodeHttpResult()`           | Returns `StatusCodeHttpResult` or `ProblemHttpResult`                                  |
+| `.ToStatusCodeHttpResult<T>()`        | Returns `StatusCodeHttpResult` or `ProblemHttpResult`                                  |
+| `.ToStatusCodeHttpResult<T,E>()`      | Returns `StatusCodeHttpResult` or custom error                                         |
+| `.ToJsonHttpResult<T>()`              | Returns `JsonHttpResult<T>` or `ProblemHttpResult`                                     |
+| `.ToJsonHttpResult<T,E>()`            | Returns `JsonHttpResult<T>` or custom error                                            |
+| `.ToNoContentHttpResult<T>()`         | Discards value of `Result<T>` and returns `NoContent` or `ProblemHttpResult`           |
+| `.ToNoContentHttpResult<T,E>()`       | Discards value of `Result<T>` and returns empty `StatusCodeHttpResult` or custom error |
+| `.ToCreatedHttpResult<T>()`           | Returns `Created<T>` or `ProblemHttpResult`                                            |
+| `.ToCreatedHttpResult<T,E>()`         | Returns `Created<T>` or custom error                                                   |
+| `.ToCreatedAtRouteHttpResult<T>()`    | Returns `CreatedAtRoute<T>` or `ProblemHttpResult`                                     |
+| `.ToCreatedAtRouteHttpResult<T,E>()`  | Returns `CreatedAtRoute<T>` or custom error                                            |
+| `.ToAcceptedHttpResult<T>()`          | Returns `Accepted<T>` or `ProblemHttpResult`                                           |
+| `.ToAcceptedHttpResult<T,E>()`        | Returns `Accepted<T>` or custom error                                                  |
+| `.ToAcceptedAtRouteHttpResult<T>()`   | Returns `AcceptedAtRoute<T>` or `ProblemHttpResult`                                    |
+| `.ToAcceptedAtRouteHttpResult<T,E>()` | Returns `AcceptedAtRoute<T>` or custom error                                           |
+| `.ToFileHttpResult<byte[]>()`         | Returns `FileContentHttpResult` or `ProblemHttpResult`                                 |
+| `.ToFileHttpResult<byte[],E>()`       | Returns `FileContentHttpResult` or custom error                                        |
+| `.ToFileStreamHttpResult<Stream>()`   | Returns `FileStreamHttpResult` or `ProblemHttpResult`                                  |
+| `.ToFileStreamHttpResult<Stream,E>()` | Returns `FileStreamHttpResult` or custom error                                         |
 
 For almost every method you can override the default status codes for Success/Failure.
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ These methods are available:
 |---------------------------------------|-----------------------------------------------------------------------------------------------|
 | `.ToStatusCodeHttpResult()`           | Returns `StatusCodeHttpResult` or `ProblemHttpResult`                                         |
 | `.ToStatusCodeHttpResult<T>()`        | Returns `StatusCodeHttpResult` or `ProblemHttpResult`                                         |
+| `.ToStatusCodeHttpResult<T,E>()`      | Returns `StatusCodeHttpResult` or custom error                                                |
 | `.ToHttpResult<T>()`                  | Returns `JsonHttpResult<T>` or `ProblemHttpResult`                                            |
 | `.ToHttpResult<T,E>()`                | Returns `JsonHttpResult<T>` or custom error                                                   |
 | `.ToNoContentHttpResult<T>()`         | Discards value of `Result<T>` and returns empty `StatusCodeHttpResult` or `ProblemHttpResult` |

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ These methods are available:
 | `.ToStatusCodeHttpResult<T>()`        | Returns `StatusCodeHttpResult` or `ProblemHttpResult`                                         |
 | `.ToStatusCodeHttpResult<T,E>()`      | Returns `StatusCodeHttpResult` or custom error                                                |
 | `.ToJsonHttpResult<T>()`              | Returns `JsonHttpResult<T>` or `ProblemHttpResult`                                            |
-| `.ToHttpResult<T,E>()`                | Returns `JsonHttpResult<T>` or custom error                                                   |
+| `.ToJsonHttpResult<T,E>()`            | Returns `JsonHttpResult<T>` or custom error                                                   |
 | `.ToNoContentHttpResult<T>()`         | Discards value of `Result<T>` and returns empty `StatusCodeHttpResult` or `ProblemHttpResult` |
 | `.ToNoContentHttpResult<T,E>()`       | Discards value of `Result<T>` and returns empty `StatusCodeHttpResult` or custom error        |
 | `.ToCreatedHttpResult<T>()`           | Returns `Created<T>` or `ProblemHttpResult`                                                   |

--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ This library uses a Source Generator to generate extension methods for your own 
 3. Use the generated extension method:
     ```csharp
     app.MapGet("/users/{id}", (string id) => {
-        return userRepository.find(id) //Result<User,UserNotFoundError>
-            .ToHttpResult();
+        return userRepository.Find(id) //Result<User,UserNotFoundError>
+            .ToHttpResult(); //returns 200 with User as payload or 404 with ProblemDetails object defined above
     });
     ```
 


### PR DESCRIPTION
closes #1 

Breaking Changes:
- rename `ToHttpResult` method to `ToStatusCodeHttpResult`
- rename `ToHttpResult<T>` to `ToJsonHttpResult<T>`
- rename `ToHttpResult<T,E>` to `ToJsonHttpResult<T,E>`
- `ToNoContentHttpResult<T>` returns `NoContent` instead of `StatusCodeHttpResult`
- `ToNoContentHttpResult<T,E>` returns `NoContent` instead of `StatusCodeHttpResult`

Changes:
- add `ToOkHttpResult<T>` method
- add `ToOkHttpResult<T,E>` method
- add `ToStatusCodeHttpResult<T>` method
- add `ToStatusCodeHttpResult<T,E>` method